### PR TITLE
fix: Escape inject pattern strings to not be treated as regular expressions

### DIFF
--- a/packages/pinion/src/ops/inject.ts
+++ b/packages/pinion/src/ops/inject.ts
@@ -38,16 +38,19 @@ export const inject = <C extends PinionContext> (template: Callable<string, C>, 
     return ctx
   }
 
+const escapeString = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 const getLineNumber = (
   pattern: string | RegExp,
   lines: string[],
   isBefore: boolean
 ) => {
-  const oneLineMatchIndex = lines.findIndex((l) => l.match(pattern))
+  const matcher = pattern instanceof RegExp ? pattern : new RegExp(escapeString(pattern), 'm')
+  const oneLineMatchIndex = lines.findIndex((l) => l.match(matcher))
 
   if (oneLineMatchIndex < 0) {
     const fullText = lines.join('\n')
-    const fullMatch = fullText.match(new RegExp(pattern, 'm'))
+    const fullMatch = fullText.match(matcher)
 
     if (fullMatch && fullMatch.length) {
       if (isBefore) {

--- a/packages/pinion/test/index.test.ts
+++ b/packages/pinion/test/index.test.ts
@@ -7,7 +7,7 @@ const expectedFileContent =
 `<!-- Prepended -->
 This is injected before
 
-# Hello world
+# Hello (world)
 
 This is injected after
 <!-- Appended -->`

--- a/packages/pinion/test/templates/pinion.ts
+++ b/packages/pinion/test/templates/pinion.ts
@@ -14,9 +14,9 @@ export interface Context extends PinionContext {
 }
 
 export const generate = (ctx: Context) => generator(ctx)
-  .then(renderTemplate('# Hello world', toHelloMd))
-  .then(inject('\nThis is injected after', after('Hello world'), toHelloMd))
-  .then(inject('This is injected before\n', before('Hello world'), toHelloMd))
+  .then(renderTemplate('# Hello (world)', toHelloMd))
+  .then(inject('\nThis is injected after', after('Hello (world)'), toHelloMd))
+  .then(inject('This is injected before\n', before(/Hello\s/), toHelloMd))
   .then(inject('<!-- Prepended -->', prepend(), toHelloMd))
   .then(inject('<!-- Appended -->', append(), toHelloMd))
   .then(prompt((ctx: Context) => [{


### PR DESCRIPTION
Since we can pass actual regular expressions already, normal string should be treated as such and not interpreted as regular expressions.