### PR TITLE
fix: Only run generators in the current folder, not recursively

### DIFF
--- a/packages/pinion/src/cli/convert.ts
+++ b/packages/pinion/src/cli/convert.ts
@@ -1,7 +1,7 @@
 import { join, dirname, relative } from 'path'
 import { stat, readFile, writeFile, mkdir } from 'fs/promises'
 import { PinionContext } from '../core'
-import { listFiles } from '../utils'
+import { listAllFiles } from '../utils'
 
 export interface ConverterContext extends PinionContext {
   file: string
@@ -39,7 +39,7 @@ export const convert = async (ctx: ConverterContext) => {
     pinion.logger.log(`Converted file ${relativeName}`)
   }
   const convertDirectory = async (directory: string) => {
-    const files = await listFiles(directory)
+    const files = await listAllFiles(directory)
 
     await Promise.all(files.map(async file =>
       (await stat(file)).isDirectory() ? convertDirectory(file) : convertFile(file)

--- a/packages/pinion/src/ops/fs.ts
+++ b/packages/pinion/src/ops/fs.ts
@@ -4,7 +4,7 @@ import {
   PinionContext, Callable, mapCallables, getCallable
 } from '../core'
 import { WriteFileOptions, promptWriteFile, overwrite } from './helpers'
-import { listFiles, merge } from '../utils'
+import { listAllFiles, merge } from '../utils'
 
 const fileName = (createFolders: boolean = false) =>
 <C extends PinionContext> (...targets: Callable<string|string[], C>[]) =>
@@ -43,7 +43,7 @@ export const copyFiles = <C extends PinionContext> (
 ) => async <T extends C> (ctx: T) => {
     const source = await getCallable(from, ctx)
     const target = await getCallable(to, ctx)
-    const fileList = await listFiles(source)
+    const fileList = await listAllFiles(source)
 
     await Promise.all(fileList.map(async file => {
       const destination = join(target, relative(source, file))

--- a/packages/pinion/src/utils.ts
+++ b/packages/pinion/src/utils.ts
@@ -35,13 +35,21 @@ export const loadModule = async (file: string) => {
 
 export const listFiles = async (folder: string, extension?: string): Promise<string[]> => {
   const list = await readdir(folder, { withFileTypes: true })
-  const fileNames = (await Promise.all(list.map(file => {
-    const fullName = path.resolve(folder, file.name)
-
-    return file.isDirectory() ? listFiles(fullName, extension) : fullName
-  }))).flat().sort()
+  const fileNames = list.filter(file => file.isFile())
+    .map(({ name }) => path.resolve(folder, name))
 
   return extension ? fileNames.filter(name => name.endsWith(extension)) : fileNames
+}
+
+export const listAllFiles = async (folder: string): Promise<string[]> => {
+  const list = await readdir(folder, { withFileTypes: true })
+  const nameList = await Promise.all(list.map(file => {
+    const fullName = path.resolve(folder, file.name)
+
+    return file.isDirectory() ? listAllFiles(fullName) : fullName
+  }))
+
+  return nameList.flat().sort()
 }
 
 export const merge = (target: { [key: string]: any }, source: { [key: string]: any }) => {

--- a/packages/pinion/test/utils.test.ts
+++ b/packages/pinion/test/utils.test.ts
@@ -1,18 +1,16 @@
 import path from 'path'
 import assert from 'assert'
-import { merge, listFiles, loadModule } from '../src/utils'
+import { merge, listAllFiles, loadModule, listFiles } from '../src/utils'
 
 describe('@feathershq/pinion/utils', () => {
-  it('listFiles', async () => {
-    const files = await listFiles(path.join(__dirname, 'templates'))
+  it('listFiles with extension', async () => {
+    const files = await listFiles(path.join(__dirname, 'templates'), '.tpl.ts')
 
-    assert.ok(files.includes(
-      path.join(__dirname, 'templates', 'pinion.ts')
-    ))
+    assert.strictEqual(files.length, 2)
   })
 
-  it('listFiles recursive', async () => {
-    const files = await listFiles(path.join(__dirname))
+  it('listAllFiles recursive', async () => {
+    const files = await listAllFiles(path.join(__dirname))
 
     assert.ok(files.length > 4)
   })


### PR DESCRIPTION
This splits file listing intp `listAllFiles` (recursive) and `listFiles` (by optional extension) which only lists local files in the folder since `runGenerators` should not run generators recursively to avoid duplicate runner mistakes.