### PR TITLE
feat: Do not merge context and remove runGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,26 +264,15 @@ export const generate = (context: Context) => generator(context)
   .then(install(['ts-node'], true))
 ```
 
-### runGenerator
-
-`runGenerator((filePart|context => filePart)[])` runs a single generator (usually in `__dirname`) from a path that can be assembled dynamically. When no extension is given it will look first for compile `.js` file and then a `.ts` file.
-
-```ts
-import { PinionContext, generator, runGenerator } from '@feathershq/pinion'
-
-export const generate = (context: Context) => generator(context)
-  .then(runGenerator(__dirname, context => context.name, 'generator')
-```
-
 ### runGenerators
 
-`runGenerators((filePart|context => filePart)[])` will run all `*.tpl.ts` or `*.tpl.js` generators in the given path alphabetically in sequence.
+`runGenerators((filePart|context => filePart)[])` will run all `*.tpl.ts` or `*.tpl.js` generators in the given path alphabetically in sequence, passing the current context.
 
 ```ts
 import { PinionContext, generator, runGenerators } from '@feathershq/pinion'
 
 export const generate = (context: Context) => generator(context)
-  .then(runGenerators(__dirname, 'commons')
+  .then(runGenerators(__dirname, 'templates')
 ```
 
 ## License

--- a/packages/pinion/src/ops/run.ts
+++ b/packages/pinion/src/ops/run.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { stat } from 'fs/promises'
 import { PinionContext, Callable, runModule, mapCallables } from '../core'
-import { listFiles, merge } from '../utils'
+import { listFiles } from '../utils'
 
 const getFileName = async <C extends PinionContext> (ctx: C, pathParts: Callable<string|string[], C>[]) => {
   const segments = (await mapCallables(pathParts, ctx)).flat()
@@ -31,7 +31,7 @@ export const runGenerators = <C extends PinionContext> (...pathParts: Callable<s
     const files = compiledFiles.length ? compiledFiles : tsFiles
 
     for (const file of files.sort()) {
-      merge(ctx, await runModule(file, ctx))
+      await runModule(file, ctx)
     }
 
     return ctx
@@ -47,5 +47,7 @@ export const runGenerator = <C extends PinionContext> (...pathParts: Callable<st
   async <T extends C> (ctx: T) => {
     const name = await getFileName(ctx, pathParts)
 
-    return merge(ctx, await runModule(name, ctx)) as T
+    await runModule(name, ctx)
+
+    return ctx
   }

--- a/packages/pinion/test/index.test.ts
+++ b/packages/pinion/test/index.test.ts
@@ -27,10 +27,15 @@ describe('@feathershq/pinion', () => {
       cwd: __dirname
     })
     const ctx = await runModule(rootGenerator, initialCtx)
+    const json = require('./tmp/testing.json')
 
-    assert.ok(ctx.second)
-    assert.deepStrictEqual(ctx.example, {
-      message: 'This is an example JSON file'
+    assert.ok(ctx.finalized)
+    assert.deepStrictEqual(json, {
+      written: true,
+      example: {
+        message: 'This is an example JSON file'
+      },
+      merged: true
     })
 
     const written = await readFile(path.join(__dirname, 'tmp', 'hello.md'))

--- a/packages/pinion/test/templates/pinion.ts
+++ b/packages/pinion/test/templates/pinion.ts
@@ -11,6 +11,7 @@ export interface Context extends PinionContext {
   order: string[]
   a: boolean
   b: boolean
+  finalized: boolean
 }
 
 export const generate = (ctx: Context) => generator(ctx)
@@ -28,3 +29,7 @@ export const generate = (ctx: Context) => generator(ctx)
   .then(install(['@feathersjs/feathers'], false, 'echo'))
   .then(copyFiles(fromFile(__dirname), toFile('tmp', 'copy')))
   .then(runGenerators(__dirname))
+  .then(ctx => ({
+    ...ctx,
+    finalized: true
+  }))

--- a/packages/pinion/test/templates/pinion.ts
+++ b/packages/pinion/test/templates/pinion.ts
@@ -1,7 +1,7 @@
 import {
-  PinionContext, generator, runGenerators, runGenerator, renderTemplate,
+  PinionContext, generator, runGenerators, renderTemplate, when,
   prompt, inject, toFile, fromFile, after, prepend, append, before,
-  install, copyFiles, when
+  install, copyFiles
 } from '../../src/index'
 
 const toHelloMd = toFile('tmp', 'hello.md')
@@ -25,8 +25,7 @@ export const generate = (ctx: Context) => generator(ctx)
     name: 'name',
     when: !ctx.name
   }]))
-  .then(when(true, runGenerator(__dirname, 'noop')))
-  .then(install(['@feathersjs/feathers'], false, 'echo'))
+  .then(when(() => true, install(['@feathersjs/feathers'], false, 'echo')))
   .then(copyFiles(fromFile(__dirname), toFile('tmp', 'copy')))
   .then(runGenerators(__dirname))
   .then(ctx => ({

--- a/packages/pinion/test/templates/second.tpl.ts
+++ b/packages/pinion/test/templates/second.tpl.ts
@@ -1,8 +1,0 @@
-import { generator } from '../../src/index'
-import { Context } from './pinion'
-
-export const generate = (ctx: Context) => generator(ctx)
-  .then(ctx => ({
-    ...ctx,
-    second: true
-  }))

--- a/packages/pinion/test/utils.test.ts
+++ b/packages/pinion/test/utils.test.ts
@@ -6,7 +6,7 @@ describe('@feathershq/pinion/utils', () => {
   it('listFiles with extension', async () => {
     const files = await listFiles(path.join(__dirname, 'templates'), '.tpl.ts')
 
-    assert.strictEqual(files.length, 2)
+    assert.strictEqual(files.length, 1)
   })
 
   it('listAllFiles recursive', async () => {


### PR DESCRIPTION
Merging contexts when running other generators might cause strange issues so `runGenerators` will now just import and run the generator.

Additionally the `runGenerator` operation is not really necessary because an individual generator can just be `import`ed where you get all the benefits of type safety.