### PR TITLE
fix: Fix spawn command to work properly with Windows

### DIFF
--- a/packages/pinion/src/core.ts
+++ b/packages/pinion/src/core.ts
@@ -80,6 +80,7 @@ export const getConfig = (initialConfig?: Partial<Configuration>): Configuration
   exec: (command: string, args: string[], options?: SpawnOptions) => {
     const child = spawn(command, args, {
       stdio: 'inherit',
+      shell: true,
       ...options
     })
 


### PR DESCRIPTION
Brought up in https://github.com/feathersjs/feathers/issues/2705, according to https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows setting `shell: true` should allow `spawn` to work as expected in Windows as well.