### PR TITLE
chore: Bring back chalk

### DIFF
--- a/packages/pinion/package.json
+++ b/packages/pinion/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@types/inquirer": "^9.0.3",
+    "chalk": "4",
     "commander": "^10.0.1",
     "inquirer": "^8.0.0",
     "ts-node": "^10.9.1"

--- a/packages/pinion/src/core.ts
+++ b/packages/pinion/src/core.ts
@@ -1,13 +1,11 @@
 import { spawn, SpawnOptions } from 'child_process'
 import inquirer from 'inquirer'
+import chalk from 'chalk'
 
 import { loadModule } from './utils'
 
 const { prompt } = inquirer
-
-const yellow = (text: string) => `\u001b[33m${text}\u001b[39m`
-const red = (text: string) => `\u001b[31m${text}\u001b[39m`
-const blue = (text: string) => `\u001b[34m${text}\u001b[39m`
+const { yellow, red, blue } = chalk
 
 export interface Logger {
   warn: (msg: string) => void


### PR DESCRIPTION
Originally removed in #31 we'll need it for GPT integration and it is a dependency of inquirer already anyway.